### PR TITLE
fix(graphql): Defining a mutation schema

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,10 +1,3 @@
-const resolver = {
-  hello() {
-    return {
-      text: 'Hello world GraphQL',
-      views: 1234
-    };
-  }
-};
+const resolver = {};
 
 module.exports = resolver;

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -2,15 +2,37 @@ const { buildSchema } = require('graphql');
 
 //  Define GraphQL Schema
 const schemaAttributes = `
-  type TestData {
-    text: String!
-    views: Int!
+  type Post {
+    _id: ID!
+    title: String!
+    content: String!
+    imageUrl: String!
+    creator: User!
+    createdAt: String!
+    updatedAt: String!
   }
-  type RootQuery {
-    hello: TestData!
+
+  type User {
+    _id: ID!
+    name: String!
+    email: String!
+    password: String
+    status: String!
+    posts: [Post!]!
   }
+
+  input UserInputData {
+    email: String!
+    name: String!
+    password: String!
+  }
+
+  type RootMutation {
+    createUser(userInput: UserInputData): User!
+  }
+
   schema {
-    query: RootQuery
+     mutation: RootMutation
   }
 `;
 


### PR DESCRIPTION
# PR's Overview
- Reset example logic in resolver
- Define a mutation schema `Post`, `User`, `UesrInputData` and root mutation