### PR TITLE
fix(type): create post function incorrect response type, format error

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -154,7 +154,7 @@ const createPost = async ({ postInput }, req) => {
 
     const userPostFormat = {
       ...createdPost._doc,
-      _id: createdPost._id.toString,
+      _id: createdPost._id.toString(),
       createdAt: createdPost.createdAt.toISOString(),
       updatedAt: createdPost.updatedAt.toISOString()
     };


### PR DESCRIPTION
Fix bug incorrect create post response type

`_id` is undefined due to incorrect convert to string 

Error message:
```
  'graphql-format-error': {
    message: "Cannot read property 'toString' of undefined",
    originalError: TypeError: Cannot read property 'toString' of undefined
```