### PR TITLE
feat(graphql): Adding getPosts query and resolver

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -170,7 +170,7 @@ const createPost = async ({ postInput }, req) => {
   }
 };
 
-const posts = async (args, req) => {
+const getPosts = async (args, req) => {
   //  Check if user not authenticated
   if (!req.isAuth) {
     const error = new Error('Not authenticated');
@@ -203,7 +203,7 @@ const resolver = {
   createUser,
   login,
   createPost,
-  posts
+  getPosts
 };
 
 module.exports = resolver;

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -26,6 +26,11 @@ const schemaAttributes = `
     userId: String!
   }
 
+  type PostData {
+    posts: [Post!]!
+    totalPosts: Int!
+  }
+
   input UserInputData {
     email: String!
     name: String!
@@ -40,6 +45,7 @@ const schemaAttributes = `
 
   type RootQuery {
     login(email: String!, password: String!): AuthData!
+    posts: PostData!
   }
 
   type RootMutation {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -45,7 +45,7 @@ const schemaAttributes = `
 
   type RootQuery {
     login(email: String!, password: String!): AuthData!
-    posts: PostData!
+    getPosts: PostData!
   }
 
   type RootMutation {


### PR DESCRIPTION
# What are changes?
- Adding get post resolver
- Graphql post schema


# Screenshot

**Expected behavior**

Commit [7359214](https://github.com/SuphawitCE/node-graphql/pull/13/commits/7359214968770840b0e8a8d8f0bdfc117b3804b6)
`posts`
<img width="1043" alt="Screen Shot 2565-10-29 at 18 40 27" src="https://user-images.githubusercontent.com/50129987/198829524-5be9804e-b06b-46e1-ae69-ed88f8f2e2de.png">


Commit [32ecedc](https://github.com/SuphawitCE/node-graphql/pull/13/commits/32ecedc417c3104fd11ce7ab2623f89ae4aa320f)

`getPosts`

<img width="1043" alt="Screen Shot 2565-10-29 at 18 42 08" src="https://user-images.githubusercontent.com/50129987/198829525-6876fe6c-abcc-4038-9e26-5a1ced985981.png">

`"message": "Not authenticated",` is expected because need to call and authenticate from client side
