### PR TITLE
fix(schema): Not required 'page' type schema

### DIFF
--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -45,7 +45,7 @@ const schemaAttributes = `
 
   type RootQuery {
     login(email: String!, password: String!): AuthData!
-    getPosts(page: Int!): PostData!
+    getPosts(page: Int): PostData!
     getPostById(id: ID!): Post!
     userStatus: User!
   }


### PR DESCRIPTION
# What are changes?
- Fix GraphQL schema type `page` to not required 


When client apps using
```graphql
query FetchPosts($page: Int)
```


# Related links
The client apps using variables
https://github.com/SuphawitCE/www-social-media-graphql/pull/15